### PR TITLE
[WIP] hotfix use get token

### DIFF
--- a/classes/ContentSurvey.php
+++ b/classes/ContentSurvey.php
@@ -377,7 +377,7 @@ class ContentSurvey extends \ContentElement
 		}
 		
 		// check survey start
-		if (\Input::post('start') || ($this->objSurvey->immediate_start == 1 && !\Input::post('FORM_SUBMIT')))
+		if (\Input::post('start') || ($this->objSurvey->immediate_start == 1 && !\Input::post('FORM_SUBMIT')) ||  || \Input::get('token'))
 		{
 			$page = 0;
 			switch ($this->objSurvey->access)
@@ -401,8 +401,25 @@ class ContentSurvey extends \ContentElement
 					}
 					break;
 				case 'anoncode':
-					$tan = \Input::post('tan');
-					if ((strcmp(\Input::post('FORM_SUBMIT'), 'tl_survey_form') == 0) && (strlen($tan)))
+				    $formCheck = false;
+				    
+				    // check GET as first
+				    if (\Input::get('token')) {
+				        $tan = \Input::get('token');
+				        if (strlen($tan)) {
+				            $formCheck = true;
+				        }
+				    }
+				    
+				    // check POST as second
+				    if (\Input::post('token')) {
+				        $tan = \Input::post('tan');
+				        if ((strcmp(\Input::post('FORM_SUBMIT'), 'tl_survey_form') == 0) && (strlen($tan))) {
+				            $formCheck = true;
+				        }
+				    }
+
+					if ($formCheck)
 					{
 						$result = $this->svy->checkPINTAN($this->objSurvey->id, "", $tan);
 						if ($result === false)


### PR DESCRIPTION
hotfix use get token
it would be nice if you could start a survey directly with a TAN token.

So far there is only the variant with page/code/123456.html which only sets the TAN in the input field. The user has to click again instead of starting immediately.

PR as "WIP