### PR TITLE
Fixed warning in FormMatrixQuestion::validator()

### DIFF
--- a/src/Resources/contao/forms/FormMatrixQuestion.php
+++ b/src/Resources/contao/forms/FormMatrixQuestion.php
@@ -214,7 +214,7 @@ class FormMatrixQuestion extends FormQuestionWidget
 
             return $varInput;
         }
-        if (\count($varInput) != \count($this->arrRows) && $this->mandatory) {
+        if ((!$varInput || \count($varInput) != \count($this->arrRows)) && $this->mandatory) {
             $this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['mandatory_matrix'], $this->title));
 
             return $varInput;


### PR DESCRIPTION
This pull request fixes a warning when validating an empty value in matrix questions. 

Following warning is fixed:
> Warning: count(): Parameter must be an array or an object that implements Countable
