### PR TITLE
Remove symfony/framework-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "php": ">=5.6.0",
     "contao/core-bundle":"~4.4",
     "hschottm/contao-textwizard":"~3.2",
-    "symfony/framework-bundle": "^3.3",
     "sonata-project/exporter": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
This package does not actually use any component from the `symfony/framework-bundle`, thus the dependency on it should be removed, as it prevents installation in newer Contao versions.

Also this package uses `DependencyInjection` and a `services.yml`, however no services are defined at all. All this could be removed as well.