### PR TITLE
Version für Contao ^4.13 und PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-[![Latest Version on Packagist](http://img.shields.io/packagist/v/hschottm/contao-survey.svg?style=flat)](https://packagist.org/packages/hschottm/contao-survey)
-[![Installations via composer per month](http://img.shields.io/packagist/dm/hschottm/contao-survey.svg?style=flat)](https://packagist.org/packages/hschottm/contao-survey)
-[![Installations via composer total](http://img.shields.io/packagist/dt/hschottm/contao-survey.svg?style=flat)](https://packagist.org/packages/hschottm/contao-survey)
-
 # contao-survey
 A contao bundle to create online surveys. Supports multiple choice questions, openended questions, matrix questions and constant sum questions. Surveys can be run as anonymized or personalized surveys for specific members. Anonymized surveys can limited to TAN access only to run a representative survey.
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":"hschottm/contao-survey",
+  "name":"arminfrey/contao-survey",
   "description":"Contao bundle to create questionnaires and run online surveys",
   "keywords":["contao", "module", "extension", "survey", "bundle"],
   "type":"contao-bundle",
@@ -11,9 +11,8 @@
     }
   ],
   "require":{
-    "php": ">=5.6.0",
     "contao/core-bundle":"~4.4",
-    "hschottm/contao-textwizard":"~3.2",
+    "hschottm/contao-textwizard":"^3.4",
     "sonata-project/exporter": "^1.0"
   },
   "require-dev": {

--- a/src/Resources/contao/classes/SurveyQuestion.php
+++ b/src/Resources/contao/classes/SurveyQuestion.php
@@ -105,7 +105,7 @@ abstract class SurveyQuestion extends \Backend
         $this->arrStatistics = [];
     }
 
-    public function exportDataToExcel($sheet, &$row)
+    public function exportDataToExcel(&$exporter, $sheet, &$row)
     {
         // overwrite in parent classes
         return [];

--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -37,12 +37,8 @@ class tl_content_survey extends tl_content
      *
      * @return array
      */
-    public function getSurveyTemplates(DataContainer $dc)
+    public function getSurveyTemplates()
     {
-        if (version_compare(VERSION.BUILD, '2.9.0', '>=')) {
-            return $this->getTemplateGroup('ce_survey', $dc->activeRecord->pid);
-        }
-
         return $this->getTemplateGroup('ce_survey');
     }
 }

--- a/src/Resources/contao/dca/tl_survey_page.php
+++ b/src/Resources/contao/dca/tl_survey_page.php
@@ -186,7 +186,7 @@ class tl_survey_page extends Backend
      *
      * @return array
      */
-    public function getSurveyTemplates(DataContainer $dc)
+    public function getSurveyTemplates(DataContainer $dc): array
     {
         return $this->getTemplateGroup('survey_', $dc->activeRecord->pid);
     }

--- a/src/Resources/contao/dca/tl_survey_page.php
+++ b/src/Resources/contao/dca/tl_survey_page.php
@@ -188,7 +188,7 @@ class tl_survey_page extends Backend
      */
     public function getSurveyTemplates(DataContainer $dc): array
     {
-        return $this->getTemplateGroup('survey_', $dc->activeRecord->pid);
+        return $this->getTemplateGroup('survey_');
     }
 
     /**

--- a/src/Resources/contao/dca/tl_survey_page.php
+++ b/src/Resources/contao/dca/tl_survey_page.php
@@ -188,11 +188,7 @@ class tl_survey_page extends Backend
      */
     public function getSurveyTemplates(DataContainer $dc)
     {
-        /**if (version_compare(VERSION.BUILD, '2.9.0', '>=')) { */
-            return $this->getTemplateGroup('survey_', $dc->activeRecord->pid);
-    /**    }
-
-        return $this->getTemplateGroup('survey_'); *//
+        return $this->getTemplateGroup('survey_', $dc->activeRecord->pid);
     }
 
     /**

--- a/src/Resources/contao/dca/tl_survey_page.php
+++ b/src/Resources/contao/dca/tl_survey_page.php
@@ -188,11 +188,11 @@ class tl_survey_page extends Backend
      */
     public function getSurveyTemplates(DataContainer $dc)
     {
-        if (version_compare(VERSION.BUILD, '2.9.0', '>=')) {
+        /**if (version_compare(VERSION.BUILD, '2.9.0', '>=')) { */
             return $this->getTemplateGroup('survey_', $dc->activeRecord->pid);
-        }
+    /**    }
 
-        return $this->getTemplateGroup('survey_');
+        return $this->getTemplateGroup('survey_'); *//
     }
 
     /**


### PR DESCRIPTION
Durch die paar Anpassungen läuft das Modul unter Contao ^4.13 und PHP8.01

Es tritt ein Fehler in src/Resources/contao/config/config.php auf beim Debuggen. Den kann ich nicht fixen.
![config php](https://user-images.githubusercontent.com/104427130/186879098-03aa1ea2-707a-4cb2-afbc-12884f8c2979.png)

Dazu reichen meine Kenntnisse nicht aus.